### PR TITLE
Custom Exceptions for Errors

### DIFF
--- a/lemon_markets/account.py
+++ b/lemon_markets/account.py
@@ -3,6 +3,7 @@ import requests
 import json
 
 from lemon_markets.config import DEFAULT_AUTH_API_URL
+from lemon_markets.exceptions import LemonConnectionException
 
 
 class Account:
@@ -50,6 +51,6 @@ class Account:
         if self._access_token_type == "bearer":
             s = "Bearer " + self.access_token
         else:
-            raise Exception("Error: unknown token type")
+            raise LemonConnectionException("Error: unknown token type")
 
         return {"Authorization": s}

--- a/lemon_markets/exceptions.py
+++ b/lemon_markets/exceptions.py
@@ -1,0 +1,22 @@
+
+class LemonException(Exception):
+    """Baseclass for exceptions raised by the sdk"""
+    pass
+
+
+class LemonConnectionException(LemonException):
+    """Raised when there is a problem with the network connection"""
+    pass
+
+
+class LemonAPIException(LemonException):
+    """Raised when the request goes through, but there is an error with the api"""
+    def __init__(self, status, errormessage):
+        self.status = status
+        self.errormessage = errormessage
+
+    def get_error_message(self):
+        return self.errormessage
+
+    def get_status_code(self):
+        return self.status

--- a/lemon_markets/helpers/api_client.py
+++ b/lemon_markets/helpers/api_client.py
@@ -21,19 +21,27 @@ class ApiClient:
         offset = None
         next = None
         results = []
-        while True:
-            offset = next
-            page_params = params.copy()
-            if offset is not None:
-                page_params['offset'] = offset
-            data = self._request(endpoint, data=data_, params=page_params)
 
-            results += data['results']
+        try:
 
-            if data['next'] is None or data['next'] <= offset:
-                break
-            else:
-                next = data['next']
+            while True:
+                offset = next
+                page_params = params.copy()
+                if offset is not None:
+                    page_params['offset'] = offset
+                data = self._request(endpoint, data=data_, params=page_params)
+
+                results += data['results']
+
+                if data['next'] is None or data['next'] <= offset:
+                    break
+                else:
+                    next = data['next']
+        except requests.Timeout:
+            raise LemonConnectionException("Network Timeout on url: %s" % url)
+
+        if data.status_code < 399:
+            raise LemonAPIException(status=data.status_code, errormessage=data.reason)
 
         return results
 

--- a/lemon_markets/helpers/api_client.py
+++ b/lemon_markets/helpers/api_client.py
@@ -38,7 +38,7 @@ class ApiClient:
                 else:
                     next = data['next']
         except requests.Timeout:
-            raise LemonConnectionException("Network Timeout on url: %s" % url)
+            raise LemonConnectionException("Network Timeout on url: %s" % endpoint)
 
         if data.status_code < 399:
             raise LemonAPIException(status=data.status_code, errormessage=data.reason)

--- a/lemon_markets/paper_money/portfolio.py
+++ b/lemon_markets/paper_money/portfolio.py
@@ -5,7 +5,6 @@ from lemon_markets.helpers.api_client import ApiClient
 from lemon_markets.account import Account
 from lemon_markets.paper_money.instrument import Instrument, Instruments
 from lemon_markets.paper_money.space import Space
-from lemon_markets.helpers.time_helper import *
 
 
 @dataclass()


### PR DESCRIPTION
There is now a file in the root direction containing the definitions of custom exceptions. The API-Client now throws exceptions when making requests, differentiating between errors regarding the network connection and errors from the API itself.

@LinusReuter have a look at the changes and feel free to merge if you agree with the changes. If you have any questions, just ask me.